### PR TITLE
fix: call Zeebe with result variable map

### DIFF
--- a/runtime-job-worker/pom.xml
+++ b/runtime-job-worker/pom.xml
@@ -43,6 +43,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/ConnectorConfig.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/ConnectorConfig.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.camunda.connector.runtime.jobworker;
 
 import java.util.ArrayList;
@@ -27,10 +28,10 @@ public class ConnectorConfig {
   public static final Pattern ZEEBE_CONNECTOR_PATTERN =
       Pattern.compile("^ZEEBE_CONNECTOR_([^_]+)_TYPE$");
 
-  private String name;
-  private String type;
+  private final String name;
+  private final String type;
   private final String[] variables;
-  private String function;
+  private final String function;
 
   /**
    * Create a connector configuration.
@@ -40,7 +41,8 @@ public class ConnectorConfig {
    * @param variables the variables the connector needs as input
    * @param className the connector function class
    */
-  public ConnectorConfig(String name, String type, String[] variables, String className) {
+  public ConnectorConfig(
+      final String name, final String type, final String[] variables, final String className) {
     this.name = name;
     this.type = type;
     this.variables = variables;
@@ -70,7 +72,7 @@ public class ConnectorConfig {
     return connectors;
   }
 
-  private static ConnectorConfig parseConnector(String name) {
+  private static ConnectorConfig parseConnector(final String name) {
 
     var type = getEnv(name, "TYPE");
     var function = getEnv(name, "FUNCTION");
@@ -79,7 +81,7 @@ public class ConnectorConfig {
     return new ConnectorConfig(name, type, variables, function);
   }
 
-  private static String getEnv(String name, String detail) {
+  private static String getEnv(final String name, final String detail) {
     return System.getenv("ZEEBE_CONNECTOR_" + name + "_" + detail);
   }
 

--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/ConnectorJobHandler.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/ConnectorJobHandler.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.camunda.connector.runtime.jobworker;
 
 import io.camunda.connector.api.ConnectorContext;
@@ -28,7 +29,7 @@ import java.util.ServiceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Job worker handler wrapper for a connector function */
+/** Job worker handler wrapper for a connector function. */
 public class ConnectorJobHandler implements JobHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConnectorJobHandler.class);
@@ -40,12 +41,12 @@ public class ConnectorJobHandler implements JobHandler {
    *
    * @param call - the connector function to call
    */
-  public ConnectorJobHandler(ConnectorFunction call) {
+  public ConnectorJobHandler(final ConnectorFunction call) {
     this.call = call;
   }
 
   @Override
-  public void handle(JobClient client, ActivatedJob job) {
+  public void handle(final JobClient client, final ActivatedJob job) {
 
     LOGGER.info("Received job {}", job.getKey());
 
@@ -68,12 +69,7 @@ public class ConnectorJobHandler implements JobHandler {
   }
 
   protected SecretProvider getEnvSecretProvider() {
-    return new SecretProvider() {
-      @Override
-      public String getSecret(String value) {
-        return System.getenv(value);
-      }
-    };
+    return System::getenv;
   }
 
   protected class JobHandlerContext implements ConnectorContext {
@@ -81,12 +77,12 @@ public class ConnectorJobHandler implements JobHandler {
     private final ActivatedJob job;
     private SecretStore secretStore;
 
-    public JobHandlerContext(ActivatedJob job) {
+    public JobHandlerContext(final ActivatedJob job) {
       this.job = job;
     }
 
     @Override
-    public void replaceSecrets(ConnectorInput input) {
+    public void replaceSecrets(final ConnectorInput input) {
       input.replaceSecrets(getSecretStore());
     }
 
@@ -99,7 +95,7 @@ public class ConnectorJobHandler implements JobHandler {
     }
 
     @Override
-    public <T extends Object> T getVariablesAsType(Class<T> cls) {
+    public <T> T getVariablesAsType(Class<T> cls) {
       return job.getVariablesAsType(cls);
     }
 

--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/Main.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/Main.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.camunda.connector.runtime.jobworker;
 
 import io.camunda.connector.api.ConnectorFunction;
@@ -86,25 +87,24 @@ public class Main {
 
       Runtime.getRuntime()
           .addShutdownHook(
-              new Thread() {
-                @Override
-                public void run() {
-                  LOGGER.info("Shutting down workers...");
-                  workers.forEach(
-                      worker -> {
-                        try {
-                          worker.close();
-                        } catch (Exception e) {
-                          ; // ignore
-                        }
-                      });
-                }
-              });
+              new Thread(
+                  () -> {
+                    LOGGER.info("Shutting down workers...");
+                    workers.forEach(
+                        worker -> {
+                          try {
+                            worker.close();
+                          } catch (Exception e) {
+                            // ignore
+                          }
+                        });
+                  }));
 
       waitForever();
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static ConnectorFunction loadConnectorFunction(String clsName) {
 
     try {

--- a/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/ConnectorJobHandlerTest.java
+++ b/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/ConnectorJobHandlerTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-public class ConnectorJobHandlerSecretsTest {
+public class ConnectorJobHandlerTest {
 
   @Nested
   class Secrets {

--- a/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/JobBuilder.java
+++ b/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/JobBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.jobworker;
+
+import static io.camunda.connector.runtime.jobworker.ConnectorJobHandler.RESULT_VARIABLE_HEADER_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import java.util.Map;
+import org.mockito.ArgumentCaptor;
+
+class JobBuilder {
+
+  public static class JobBuilderStep {
+
+    private final JobClient jobClient;
+    private final ActivatedJob job;
+    private final CompleteJobCommandStep1 completeCommand;
+
+    public JobBuilderStep() {
+
+      this.jobClient = mock(JobClient.class);
+      this.job = mock(ActivatedJob.class);
+      this.completeCommand = mock(CompleteJobCommandStep1.class, RETURNS_DEEP_STUBS);
+
+      when(jobClient.newCompleteCommand(any())).thenReturn(completeCommand);
+      when(job.getKey()).thenReturn(-1l);
+    }
+
+    public JobBuilderStep withHeaders(Map<String, String> headers) {
+      when(job.getCustomHeaders()).thenReturn(headers);
+
+      return this;
+    }
+
+    public JobBuilderStep withResultHeader(String value) {
+      return withHeader(RESULT_VARIABLE_HEADER_NAME, value);
+    }
+
+    public JobBuilderStep withHeader(String key, String value) {
+      return withHeaders(Map.of(key, value));
+    }
+
+    public JobResult execute(ConnectorJobHandler connectorJobHandler) {
+
+      // when
+      connectorJobHandler.handle(jobClient, job);
+
+      var variablesCaptor = ArgumentCaptor.forClass(Map.class);
+
+      // then
+      verify(completeCommand).variables(variablesCaptor.capture());
+
+      return new JobResult(variablesCaptor.getValue());
+    }
+  }
+
+  public static class JobResult {
+
+    private final Map<String, Object> variables;
+
+    public JobResult(Map<String, Object> variables) {
+      this.variables = variables;
+    }
+
+    public Map<String, Object> getVariables() {
+      return variables;
+    }
+
+    public Object getVariable(String key) {
+      return variables.get(key);
+    }
+  }
+
+  static JobBuilderStep create() {
+    return new JobBuilderStep();
+  }
+}

--- a/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/TestSecretProvider.java
+++ b/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/TestSecretProvider.java
@@ -16,8 +16,9 @@
  */
 package io.camunda.connector.runtime.jobworker;
 
+import static java.util.Collections.singletonMap;
+
 import io.camunda.connector.api.SecretProvider;
-import java.util.Collections;
 import java.util.Map;
 
 public class TestSecretProvider implements SecretProvider {
@@ -25,12 +26,10 @@ public class TestSecretProvider implements SecretProvider {
   public static final String SECRET_NAME = "FOO";
   public static final String SECRET_VALUE = "bar";
 
-  private static final Map<String, String> SECRETS =
-      Collections.singletonMap(SECRET_NAME, SECRET_VALUE);
+  private static final Map<String, String> SECRETS = singletonMap(SECRET_NAME, SECRET_VALUE);
 
   @Override
   public String getSecret(String value) {
-    System.out.println("REPLACE " + value);
     return SECRETS.get(value);
   }
 }


### PR DESCRIPTION
## Description

Wraps the connector function result in a map before passing it
on to Zeebe. The result is only returned if a `resultVariable`
header is defined on the task (consistent with C8 SaaS Bridge behavior).

## Related issues

* related to #8 (has a broader scope including evaluating `resultExpression` with FEEL, for example)
* closes #45 

