### PR TITLE
feat: support secret replacement on maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 *.classpath
 *.project
 *.settings
+*.iml

--- a/core/src/main/java/io/camunda/connector/api/ConnectorFunction.java
+++ b/core/src/main/java/io/camunda/connector/api/ConnectorFunction.java
@@ -27,7 +27,7 @@ public interface ConnectorFunction {
    * to fetch objects provided by the environment transparently.
    *
    * <p>The connector can return any serializable object that will be passed to the
-   * environment-specifc runtime.
+   * environment-specific runtime.
    *
    * <p>Checked exceptions can be handled by the connector if desired. The environment-specifc
    * runtime will also take care of catching all checked exceptions from the connector function.

--- a/core/src/main/java/io/camunda/connector/api/SecretStore.java
+++ b/core/src/main/java/io/camunda/connector/api/SecretStore.java
@@ -29,7 +29,7 @@ public class SecretStore {
 
   private static final Pattern SECRET_PATTERN = Pattern.compile("^secrets\\.(\\S+)$");
 
-  protected SecretProvider secretProvider;
+  protected final SecretProvider secretProvider;
 
   /**
    * Create a store with a specific {@link SecretProvider}.

--- a/core/src/main/java/io/camunda/connector/test/ConnectorContextBuilder.java
+++ b/core/src/main/java/io/camunda/connector/test/ConnectorContextBuilder.java
@@ -21,7 +21,6 @@ import io.camunda.connector.api.SecretProvider;
 import io.camunda.connector.api.SecretStore;
 import io.camunda.connector.api.ValidationProvider;
 import io.camunda.connector.impl.AbstractConnectorContext;
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,8 +28,8 @@ import java.util.Optional;
 /** Test helper class for creating a {@link ConnectorContext} with a fluent API. */
 public class ConnectorContextBuilder {
 
-  protected Map<String, String> secrets = new HashMap<>();
-  protected SecretProvider secretProvider = (name) -> secrets.get(name);
+  protected final Map<String, String> secrets = new HashMap<>();
+  protected SecretProvider secretProvider = secrets::get;
 
   protected ValidationProvider validationProvider;
 
@@ -156,16 +155,6 @@ public class ConnectorContextBuilder {
     @Override
     public ValidationProvider getValidationProvider() {
       return Optional.ofNullable(validationProvider).orElseGet(super::getValidationProvider);
-    }
-
-    @Override
-    public <T> T getProperty(Object input, Field field) {
-      return super.getProperty(input, field);
-    }
-
-    @Override
-    public void setProperty(Object input, Field field, Object property) {
-      super.setProperty(input, field, property);
     }
   }
 }

--- a/core/src/test/java/io/camunda/connector/impl/ConnectorContextTest.java
+++ b/core/src/test/java/io/camunda/connector/impl/ConnectorContextTest.java
@@ -16,118 +16,363 @@
  */
 package io.camunda.connector.impl;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
+import io.camunda.connector.api.ConnectorContext;
+import io.camunda.connector.impl.secrets.*;
 import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.test.ConnectorContextBuilder.TestConnectorContext;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 
-public class ConnectorContextTest {
-  private static Field fieldForName(Class<?> clazz, String fieldName) {
+class ConnectorContextTest {
+
+  @Nested
+  class FieldAccessTests {
+
+    @TestFactory
+    public Stream<DynamicTest> shouldGetPropertyFromField() {
+      // given
+      TestInput testInput = new TestInput();
+      Stream<GetPropertyTestInput> input =
+          Stream.of(
+              new GetPropertyTestInput("publicField", testInput.publicField),
+              new GetPropertyTestInput("protectedField", testInput.protectedField),
+              new GetPropertyTestInput("privateField", testInput.getPrivateField()),
+              new GetPropertyTestInput("finalField", testInput.finalField),
+              new GetPropertyTestInput("packageField", testInput.packageField));
+      ThrowingConsumer<GetPropertyTestInput> executor =
+          in -> {
+            // when
+            String content =
+                AbstractConnectorContext.getProperty(testInput, fieldForName(in.fieldName));
+            // then
+            assertThat(content).isEqualTo(in.expectedContent);
+          };
+      return DynamicTest.stream(input, i -> i.fieldName, executor);
+    }
+
+    @TestFactory
+    public Stream<DynamicTest> shouldSetPropertyToField() {
+      // given
+      TestInput testInput = new TestInput();
+      String modified = "modified";
+      Stream<SetPropertyTestInput> input =
+          Stream.of(
+              new SetPropertyTestInput("publicField", testInput::getPublicField),
+              new SetPropertyTestInput("protectedField", testInput::getProtectedField),
+              new SetPropertyTestInput("privateField", testInput::getPrivateField),
+              new SetPropertyTestInput("packageField", testInput::getPackageField));
+      ThrowingConsumer<SetPropertyTestInput> executor =
+          in -> {
+            // when
+            AbstractConnectorContext.setProperty(testInput, fieldForName(in.fieldName), modified);
+            // then
+            assertThat(in.getter.get()).isEqualTo(modified);
+          };
+      return DynamicTest.stream(input, i -> i.fieldName, executor);
+    }
+
+    @Test
+    public void shouldThrowWhenSettingOnFinalField() {
+      // given
+      TestInput testInput = new TestInput();
+      String modified = "modified";
+      Exception expected =
+          catchException(
+              () ->
+                  // when
+                  AbstractConnectorContext.setProperty(
+                      testInput, fieldForName("finalField"), modified));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage(
+              "Cannot invoke set or setter on final field 'finalField' of type class io.camunda.connector.impl.TestInput");
+    }
+  }
+
+  @Nested
+  class SecretsTests {
+    @Test
+    void shouldReplaceNestedSecrets() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNestedObject();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.secretContainer.getSecretField()).isEqualTo("plain");
+      // it does not replace secrets in nested properties that are not marked
+      assertThat(testInput.otherProperty.getSecretField()).isEqualTo("secrets.s3cr3t");
+    }
+
+    @Test
+    void shouldIgnoreAnnotatedNullValues() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNestedObject();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.nullContainer).isNull();
+    }
+
+    @Test
+    void shouldReplaceSecretsInStringList() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringList();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.stringList).allMatch(s -> List.of("plain", "foo").contains(s));
+    }
+
+    @Test
+    void shouldReplaceSecretsInObjectList() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectList();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.inputList).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInNumberList() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNumberList();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Element at index 0 in list has no nested properties and is no String!");
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInImmutableStringList() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringListImmutable();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("List is immutable but contains String secrets to replace!");
+    }
+
+    @Test
+    void shouldReplaceSecretsInObjectSet() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectSet();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.inputSet).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInStringSet() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringSet();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Element in iterable has no nested properties!");
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInNumberSet() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNumberSet();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Element in iterable has no nested properties!");
+    }
+
+    @Test
+    void shouldReplaceSecretsInStringArray() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringArray();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.stringArray).allMatch(s -> List.of("plain", "foo").contains(s));
+    }
+
+    @Test
+    void shouldReplaceSecretsInObjectArray() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectArray();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.inputArray).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInNumberArray() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNumberArray();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Element at index 0 in array has no nested properties and is no String!");
+    }
+
+    @Test
+    void shouldReplaceSecretsInStringMap() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringMap();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.stringMap)
+          .allSatisfy((key, value) -> assertThat(List.of("plain", "foo")).contains(value));
+    }
+
+    @Test
+    void shouldReplaceSecretsInObjectMap() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectMap();
+      // when
+      connectorContext.replaceSecrets(testInput);
+      // then
+      assertThat(testInput.inputMap)
+          .allSatisfy((key, value) -> assertThat(value.getSecretField()).isEqualTo("plain"));
+    }
+
+    @Test
+    void shouldReplaceSecretsInImmutableStringMap() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputStringMapImmutable();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Map is immutable but contains String secrets to replace!");
+    }
+
+    @Test
+    void shouldFailIfReplaceSecretsInNumberMap() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputNumberMap();
+      // when
+      Exception expected = catchException(() -> connectorContext.replaceSecrets(testInput));
+      // then
+      assertThat(expected)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Element at key")
+          .hasMessageContaining("in map has no nested properties and is no String!");
+    }
+
+    @Test
+    void shouldReplaceSecretsInRootList() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectList();
+      // when
+      connectorContext.replaceSecrets(testInput.inputList);
+      // then
+      assertThat(testInput.inputList).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldReplaceSecretsInRootSet() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectSet();
+      // when
+      connectorContext.replaceSecrets(testInput.inputSet);
+      // then
+      assertThat(testInput.inputSet).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldReplaceSecretsInRootArray() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectArray();
+      // when
+      connectorContext.replaceSecrets(testInput.inputArray);
+      // then
+      assertThat(testInput.inputArray).extracting("secretField").allMatch("plain"::equals);
+    }
+
+    @Test
+    void shouldReplaceSecretsInRootMap() {
+      // given
+      ConnectorContext connectorContext =
+          ConnectorContextBuilder.create().secret("s3cr3t", "plain").build();
+      final var testInput = new InputObjectMap();
+      // when
+      connectorContext.replaceSecrets(testInput.inputMap);
+      // then
+      assertThat(testInput.inputMap)
+          .allSatisfy((key, value) -> assertThat(value.getSecretField()).isEqualTo("plain"));
+    }
+  }
+
+  private static Field fieldForName(String fieldName) {
     try {
-      return clazz.getDeclaredField(fieldName);
+      return TestInput.class.getDeclaredField(fieldName);
     } catch (NoSuchFieldException e) {
       throw new RuntimeException(e);
     }
   }
 
-  @TestFactory
-  public Stream<DynamicTest> shouldGetPropertyFromField() {
-    // given
-    TestConnectorContext connectorContext = ConnectorContextBuilder.create().build();
-    TestInput testInput = new TestInput();
-    Stream<GetPropertyTestInput> input =
-        Stream.of(
-            new GetPropertyTestInput("publicField", testInput.publicField),
-            new GetPropertyTestInput("protectedField", testInput.protectedField),
-            new GetPropertyTestInput("privateField", testInput.getPrivateField()),
-            new GetPropertyTestInput("finalField", testInput.finalField),
-            new GetPropertyTestInput("packageField", testInput.packageField));
-    ThrowingConsumer<GetPropertyTestInput> executor =
-        in -> {
-          // when
-          String content =
-              connectorContext.getProperty(testInput, fieldForName(TestInput.class, in.fieldName));
-          // then
-          assertEquals(in.expectedContent, content);
-        };
-    return DynamicTest.stream(input, i -> i.fieldName, executor);
-  }
-
-  @TestFactory
-  public Stream<DynamicTest> shouldSetPropertyToField() {
-    // given
-    TestConnectorContext connectorContext = ConnectorContextBuilder.create().build();
-    TestInput testInput = new TestInput();
-    String modified = "modified";
-    Stream<SetPropertyTestInput> input =
-        Stream.of(
-            new SetPropertyTestInput("publicField", testInput::getPublicField),
-            new SetPropertyTestInput("protectedField", testInput::getProtectedField),
-            new SetPropertyTestInput("privateField", testInput::getPrivateField),
-            new SetPropertyTestInput("packageField", testInput::getPackageField));
-    ThrowingConsumer<SetPropertyTestInput> executor =
-        in -> {
-          // when
-          connectorContext.setProperty(
-              testInput, fieldForName(TestInput.class, in.fieldName), modified);
-          // then
-          assertEquals(modified, in.getter.get());
-        };
-    return DynamicTest.stream(input, i -> i.fieldName, executor);
-  }
-
-  @Test
-  public void shouldThrowWhenSettingOnFinalField() {
-    // given
-    TestConnectorContext connectorContext = ConnectorContextBuilder.create().build();
-    TestInput testInput = new TestInput();
-    String modified = "modified";
-    IllegalStateException exception =
-        assertThrows(
-            IllegalStateException.class,
-            () ->
-                // when
-                connectorContext.setProperty(
-                    testInput, fieldForName(TestInput.class, "finalField"), modified));
-    // then
-    assertEquals(
-        "Cannot invoke set or setter on final field 'finalField' of type class io.camunda.connector.impl.TestInput",
-        exception.getMessage());
-  }
-
-  @Test
-  public void shouldReplaceSecretsAlongAnnotations() {
-    // given
-    TestConnectorContext connectorContext =
-        ConnectorContextBuilder.create().secret("s3cr3t", "s3cr3t").build();
-    ComplexTestInput testInput =
-        new ComplexTestInput(new ComplexTestInput(new ComplexTestInput(null)));
-    // when
-    connectorContext.replaceSecrets(testInput);
-    // then
-    ComplexTestInput testedInput = testInput;
-    while (testedInput != null) {
-      for (TestInput input : testInput.inputArray) {
-        assertEquals("s3cr3t", input.getSecretField());
-      }
-      testInput.testInputs.forEach(input -> assertEquals("s3cr3t", input.getSecretField()));
-      assertEquals("s3cr3t", testInput.secretContainer.getSecretField());
-      // it does not replace secrets in nested properties that are not marked
-      assertEquals("secrets.s3cr3t", testInput.otherProperty.getSecretField());
-      testedInput = testedInput.complexInput;
-    }
-  }
-
   private static class SetPropertyTestInput {
-    private String fieldName;
-    private Supplier<String> getter;
+    private final String fieldName;
+    private final Supplier<String> getter;
 
     public SetPropertyTestInput(String fieldName, Supplier<String> getter) {
       this.fieldName = fieldName;
@@ -136,8 +381,8 @@ public class ConnectorContextTest {
   }
 
   private static class GetPropertyTestInput {
-    private String fieldName;
-    private String expectedContent;
+    private final String fieldName;
+    private final String expectedContent;
 
     public GetPropertyTestInput(String fieldName, String expectedContent) {
       this.fieldName = fieldName;

--- a/core/src/test/java/io/camunda/connector/impl/TestInput.java
+++ b/core/src/test/java/io/camunda/connector/impl/TestInput.java
@@ -18,7 +18,7 @@ package io.camunda.connector.impl;
 
 import io.camunda.connector.api.annotation.Secret;
 
-class TestInput {
+public class TestInput {
   public final String finalField = "final";
   public String publicField = "public";
   protected String protectedField = "protected";

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputNestedObject.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputNestedObject.java
@@ -14,21 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import io.camunda.connector.impl.TestInput;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputNestedObject {
+  @Secret public final TestInput secretContainer = new TestInput();
+  @Secret public final TestInput nullContainer = null;
+  public final TestInput otherProperty = new TestInput();
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberArray.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberArray.java
@@ -14,21 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputNumberArray {
+  @Secret public Number[] numberArray = new Number[] {3, 5.6f};
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberList.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberList.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.ArrayList;
+import java.util.List;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputNumberList {
+  @Secret public List<Number> numberList = new ArrayList<>(List.of(3, 5.6f));
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberMap.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberMap.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.HashMap;
+import java.util.Map;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputNumberMap {
+  @Secret public Map<String, Number> stringMap = new HashMap<>(Map.of("bar", 3, "baz", 5.6f));
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberSet.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputNumberSet.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.HashSet;
+import java.util.Set;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputNumberSet {
+  @Secret public Set<Number> numberSet = new HashSet<>(Set.of(3, 5.6f));
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectArray.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectArray.java
@@ -14,20 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.impl;
+package io.camunda.connector.impl.secrets;
 
 import io.camunda.connector.api.annotation.Secret;
-import java.util.Set;
+import io.camunda.connector.impl.TestInput;
 
-public class ComplexTestInput {
-  @Secret public TestInput[] inputArray = new TestInput[] {new TestInput(), new TestInput()};
-  @Secret public Set<TestInput> testInputs = Set.of(new TestInput(), new TestInput());
-  @Secret public TestInput secretContainer = new TestInput();
-  public TestInput otherProperty = new TestInput();
-
-  @Secret public ComplexTestInput complexInput;
-
-  public ComplexTestInput(ComplexTestInput complexInput) {
-    this.complexInput = complexInput;
-  }
+public class InputObjectArray {
+  @Secret public final TestInput[] inputArray = new TestInput[] {new TestInput(), new TestInput()};
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectList.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectList.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import io.camunda.connector.impl.TestInput;
+import java.util.List;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputObjectList {
+  @Secret public final List<TestInput> inputList = List.of(new TestInput(), new TestInput());
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectMap.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectMap.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import io.camunda.connector.impl.TestInput;
+import java.util.Map;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputObjectMap {
+  @Secret public final Map<String, TestInput> inputMap = Map.of("bar", new TestInput());
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectSet.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputObjectSet.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import io.camunda.connector.impl.TestInput;
+import java.util.Set;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputObjectSet {
+  @Secret public final Set<TestInput> inputSet = Set.of(new TestInput(), new TestInput());
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringArray.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringArray.java
@@ -14,21 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringArray {
+  @Secret public final String[] stringArray = new String[] {"secrets.s3cr3t", "foo"};
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringList.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringList.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.ArrayList;
+import java.util.List;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringList {
+  @Secret public final List<String> stringList = new ArrayList<>(List.of("secrets.s3cr3t", "foo"));
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringListImmutable.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringListImmutable.java
@@ -14,21 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.List;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringListImmutable {
+  @Secret public List<String> stringSet = List.of("secrets.s3cr3t", "foo");
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringMap.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringMap.java
@@ -14,21 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.HashMap;
+import java.util.Map;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringMap {
+  @Secret
+  public final Map<String, String> stringMap =
+      new HashMap<>(Map.of("bar", "secrets.s3cr3t", "baz", "foo"));
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringMapImmutable.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringMapImmutable.java
@@ -14,21 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.Map;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringMapImmutable {
+  @Secret public Map<String, String> stringMap = Map.of("foo", "secrets.s3cr3t");
 }

--- a/core/src/test/java/io/camunda/connector/impl/secrets/InputStringSet.java
+++ b/core/src/test/java/io/camunda/connector/impl/secrets/InputStringSet.java
@@ -14,21 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.validation;
+package io.camunda.connector.impl.secrets;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.camunda.connector.api.annotation.Secret;
+import java.util.HashSet;
+import java.util.Set;
 
-import io.camunda.connector.api.ValidationProvider;
-import io.camunda.connector.test.ConnectorContextBuilder;
-import io.camunda.connector.validation.impl.DefaultValidationProvider;
-import org.junit.jupiter.api.Test;
-
-class ValidatorServiceLoaderTest {
-
-  @Test
-  public void shouldDiscoverValidator() {
-    ValidationProvider validationProvider =
-        ConnectorContextBuilder.create().build().getValidationProvider();
-    assertThat(validationProvider).isOfAnyClassIn(DefaultValidationProvider.class);
-  }
+public class InputStringSet {
+  @Secret public Set<String> stringSet = new HashSet<>(Set.of("secrets.s3cr3t", "foo"));
 }

--- a/core/src/test/java/io/camunda/connector/test/ConnectorContextBuilderTest.java
+++ b/core/src/test/java/io/camunda/connector/test/ConnectorContextBuilderTest.java
@@ -86,7 +86,7 @@ public class ConnectorContextBuilderTest {
     var context = ConnectorContextBuilder.create().build();
 
     // when
-    var exception = catchException(() -> context.getVariables());
+    var exception = catchException(context::getVariables);
 
     // then
     assertThat(exception).hasMessage("variablesAsJSON not provided");

--- a/core/src/test/java/io/camunda/connector/test/ConnectorFunctionTest.java
+++ b/core/src/test/java/io/camunda/connector/test/ConnectorFunctionTest.java
@@ -16,7 +16,8 @@
  */
 package io.camunda.connector.test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import io.camunda.connector.example.ExampleFunction;
 import io.camunda.connector.example.ExampleInput;

--- a/validation/src/test/java/io/camunda/connector/validation/ValidationProviderTest.java
+++ b/validation/src/test/java/io/camunda/connector/validation/ValidationProviderTest.java
@@ -16,14 +16,14 @@
  */
 package io.camunda.connector.validation;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchException;
 
 import io.camunda.connector.api.ValidationProvider;
 import io.camunda.connector.impl.ConnectorInputException;
 import io.camunda.connector.validation.impl.DefaultValidationProvider;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 class ValidationProviderTest {
   private static final ValidationProvider VALIDATION_PROVIDER = new DefaultValidationProvider();
@@ -34,10 +34,11 @@ class ValidationProviderTest {
     User user =
         mockUser(
             "Peter Parker", "peter.parker@marvel.com", "Definitely not a super hero", 18, true);
-    // when
-    Executable ex = () -> VALIDATION_PROVIDER.validate(user);
     // then
-    assertDoesNotThrow(ex);
+    assertThatNoException()
+        .isThrownBy(
+            // when
+            () -> VALIDATION_PROVIDER.validate(user));
   }
 
   @Test
@@ -45,14 +46,14 @@ class ValidationProviderTest {
     // given
     User user = mockUser("Green Goblin", "weird", "Definitely not a trustworthy person", 60, false);
     // when
-    ConnectorInputException exception =
-        assertThrows(ConnectorInputException.class, () -> VALIDATION_PROVIDER.validate(user));
+    Exception exception = catchException(() -> VALIDATION_PROVIDER.validate(user));
     // then
-    assertThat(exception.getMessage())
-        .startsWith(
+    assertThat(exception)
+        .isInstanceOf(ConnectorInputException.class)
+        .hasMessageStartingWith(
             "jakarta.validation.ValidationException: Found constraints violated while validating input:")
-        .contains("- working: must be true")
-        .contains("- email: Email should be valid");
+        .hasMessageContaining("- working:")
+        .hasMessageContaining("- email: Email should be valid");
   }
 
   private User mockUser(String name, String email, String aboutMe, int age, boolean working) {


### PR DESCRIPTION
## Description

Supports replacing secrets in Java Maps. Also enables replacing String secrets in Lists, Arrays, and Maps directly.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #78

