### PR TITLE
feat: add `OutboundConnector` annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Include the [connector core](./core) via maven:
 Define your connector logic through the [`OutboundConnectorFunction`](./core/src/main/java/io/camunda/connector/api/outbound/OutboundConnectorFunction.java) interface:
 
 ```java
+
+@OutboundConnector(
+    name = "PING",
+    inputVariables = {"caller"},
+    taskType = "io.camunda.example.PingConnector:1"
+)
 public class PingConnector implements OutboundConnectorFunction {
 
   @Override

--- a/core/README.md
+++ b/core/README.md
@@ -7,6 +7,12 @@ The foundation for re-usable connector functionality.
 A connector implements [`ConnectorFunction#execute(ConnectorContext)`](./src/main/java/io/camunda/connector/api/ConnectorFunction.java) to define the connector logic.
 
 ```java
+
+@OutboundConnector(
+    name = "PING",
+    inputVariables = {"caller"},
+    taskType = "io.camunda.example.PingConnector:1"
+)
 public class PingConnector implements ConnectorFunction {
 
   @Override

--- a/core/src/main/java/io/camunda/connector/api/annotation/OutboundConnector.java
+++ b/core/src/main/java/io/camunda/connector/api/annotation/OutboundConnector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Marks an outbound connector and configures meta-data. */
+@Target(value = {ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OutboundConnector {
+
+  /** Name of the connector */
+  String name();
+
+  /** Input variables the connector reads */
+  String[] inputVariables();
+
+  /** Task type the connector registers for. */
+  String taskType();
+}

--- a/core/src/main/java/io/camunda/connector/impl/ConnectorUtil.java
+++ b/core/src/main/java/io/camunda/connector/impl/ConnectorUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.impl;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration;
+import java.util.Optional;
+
+public final class ConnectorUtil {
+
+  private ConnectorUtil() {}
+
+  public static Optional<OutboundConnectorConfiguration> getOutboundConnectorConfiguration(
+      Class<?> cls) {
+    return Optional.ofNullable(cls.getAnnotation(OutboundConnector.class))
+        .map(
+            annotation ->
+                new OutboundConnectorConfiguration(
+                    annotation.name(), annotation.inputVariables(), annotation.taskType()));
+  }
+}

--- a/core/src/main/java/io/camunda/connector/impl/outbound/OutboundConnectorConfiguration.java
+++ b/core/src/main/java/io/camunda/connector/impl/outbound/OutboundConnectorConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.impl.outbound;
+
+public class OutboundConnectorConfiguration {
+
+  private final String name;
+  private final String[] inputVariables;
+  private final String taskType;
+
+  public OutboundConnectorConfiguration(String name, String[] inputVariables, String taskType) {
+    this.name = name;
+    this.inputVariables = inputVariables;
+    this.taskType = taskType;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String[] getInputVariables() {
+    return inputVariables;
+  }
+
+  public String getTaskType() {
+    return taskType;
+  }
+}

--- a/core/src/test/java/io/camunda/connector/impl/ConnectorUtilTest.java
+++ b/core/src/test/java/io/camunda/connector/impl/ConnectorUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.connector.api.annotation.OutboundConnector;
+import io.camunda.connector.impl.outbound.OutboundConnectorConfiguration;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class ConnectorUtilTest {
+
+  @Nested
+  class GetOutboundConnectorConfiguration {
+
+    @Test
+    public void shouldRetrieveConnectorConfiguration() {
+
+      // when
+      Optional<OutboundConnectorConfiguration> configuration =
+          ConnectorUtil.getOutboundConnectorConfiguration(AnnotatedFunction.class);
+
+      // then
+      assertThat(configuration)
+          .isPresent()
+          .hasValueSatisfying(
+              config -> {
+                assertThat(config.getName()).isEqualTo("ANNOTATED");
+                assertThat(config.getTaskType()).isEqualTo("io.camunda.Annotated");
+                assertThat(config.getInputVariables()).isEqualTo(new String[] {"FOO"});
+              });
+    }
+
+    @Test
+    public void shouldHandleMissingConnectorConfiguration() {
+
+      // when
+      Optional<OutboundConnectorConfiguration> configuration =
+          ConnectorUtil.getOutboundConnectorConfiguration(UnannotatedFunction.class);
+
+      // then
+      assertThat(configuration).isNotPresent();
+    }
+  }
+}
+
+@OutboundConnector(
+    name = "ANNOTATED",
+    inputVariables = {"FOO"},
+    taskType = "io.camunda.Annotated")
+class AnnotatedFunction {}
+
+class UnannotatedFunction {}


### PR DESCRIPTION
## Description

Adds the `OutboundConnector` annotation to use to discover default connector configuration.

## Related issues

Related to https://github.com/camunda/connector-sdk/issues/12