### PR TITLE
chore: rename `OutboundConnector#{taskType -> type}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Define your connector logic through the [`OutboundConnectorFunction`](./core/src
 @OutboundConnector(
     name = "PING",
     inputVariables = {"caller"},
-    taskType = "io.camunda.example.PingConnector:1"
+    type = "io.camunda.example.PingConnector:1"
 )
 public class PingConnector implements OutboundConnectorFunction {
 

--- a/core/README.md
+++ b/core/README.md
@@ -11,7 +11,7 @@ A connector implements [`ConnectorFunction#execute(ConnectorContext)`](./src/mai
 @OutboundConnector(
     name = "PING",
     inputVariables = {"caller"},
-    taskType = "io.camunda.example.PingConnector:1"
+    type = "io.camunda.example.PingConnector:1"
 )
 public class PingConnector implements ConnectorFunction {
 

--- a/core/src/main/java/io/camunda/connector/api/annotation/OutboundConnector.java
+++ b/core/src/main/java/io/camunda/connector/api/annotation/OutboundConnector.java
@@ -32,6 +32,6 @@ public @interface OutboundConnector {
   /** Input variables the connector reads */
   String[] inputVariables();
 
-  /** Task type the connector registers for. */
-  String taskType();
+  /** Job / task type the connector registers for */
+  String type();
 }

--- a/core/src/main/java/io/camunda/connector/impl/ConnectorUtil.java
+++ b/core/src/main/java/io/camunda/connector/impl/ConnectorUtil.java
@@ -30,6 +30,6 @@ public final class ConnectorUtil {
         .map(
             annotation ->
                 new OutboundConnectorConfiguration(
-                    annotation.name(), annotation.inputVariables(), annotation.taskType()));
+                    annotation.name(), annotation.inputVariables(), annotation.type()));
   }
 }

--- a/core/src/main/java/io/camunda/connector/impl/outbound/OutboundConnectorConfiguration.java
+++ b/core/src/main/java/io/camunda/connector/impl/outbound/OutboundConnectorConfiguration.java
@@ -20,12 +20,12 @@ public class OutboundConnectorConfiguration {
 
   private final String name;
   private final String[] inputVariables;
-  private final String taskType;
+  private final String type;
 
-  public OutboundConnectorConfiguration(String name, String[] inputVariables, String taskType) {
+  public OutboundConnectorConfiguration(String name, String[] inputVariables, String type) {
     this.name = name;
     this.inputVariables = inputVariables;
-    this.taskType = taskType;
+    this.type = type;
   }
 
   public String getName() {
@@ -36,7 +36,7 @@ public class OutboundConnectorConfiguration {
     return inputVariables;
   }
 
-  public String getTaskType() {
-    return taskType;
+  public String getType() {
+    return type;
   }
 }

--- a/core/src/test/java/io/camunda/connector/impl/ConnectorUtilTest.java
+++ b/core/src/test/java/io/camunda/connector/impl/ConnectorUtilTest.java
@@ -42,7 +42,7 @@ public class ConnectorUtilTest {
           .hasValueSatisfying(
               config -> {
                 assertThat(config.getName()).isEqualTo("ANNOTATED");
-                assertThat(config.getTaskType()).isEqualTo("io.camunda.Annotated");
+                assertThat(config.getType()).isEqualTo("io.camunda.Annotated");
                 assertThat(config.getInputVariables()).isEqualTo(new String[] {"FOO"});
               });
     }
@@ -63,7 +63,7 @@ public class ConnectorUtilTest {
 @OutboundConnector(
     name = "ANNOTATED",
     inputVariables = {"FOO"},
-    taskType = "io.camunda.Annotated")
+    type = "io.camunda.Annotated")
 class AnnotatedFunction {}
 
 class UnannotatedFunction {}


### PR DESCRIPTION
Aligns it with our (albeit ambiguous) documentation and also pins us less to Zeebe specifics ("Job worker").

## Description

As discussed with @tmetzke we're already talking about the generic _type_ in some of our places. Let us establish it ("connector run-times have a _type_ of task / job / whatever they can execute").

## Related issues

Related to #12 