### PR TITLE
fix: use colon for classpath resources

### DIFF
--- a/runtime-job-worker/README.md
+++ b/runtime-job-worker/README.md
@@ -54,7 +54,7 @@ The run-time picks up outbound connectors available on the classpath automatical
 It uses the default configuration specified through the `@OutboundConnector` annotation in these cases.
 
 ```bash
-java -cp 'connector-runtime-job-worker-with-dependencies.jar;connector-http-json-with-dependencies.jar' \
+java -cp 'connector-runtime-job-worker-with-dependencies.jar:connector-http-json-with-dependencies.jar' \
     io.camunda.connector.runtime.jobworker.Main
 ```
 
@@ -75,7 +75,7 @@ Specifying optional values allow you to override `@OutboundConnector` provided c
 CONNECTOR_HTTPJSON_FUNCTION=io.camunda.connector.http.HttpJsonFunction
 CONNECTOR_HTTPJSON_TYPE=non-default-httpjson-task-type
 
-java -cp 'connector-runtime-job-worker-with-dependencies.jar;connector-http-json-with-dependencies.jar' \
+java -cp 'connector-runtime-job-worker-with-dependencies.jar:connector-http-json-with-dependencies.jar' \
     io.camunda.connector.runtime.jobworker.Main
 ```
 


### PR DESCRIPTION
## Description

Fix the classpath examples to use `:` instead of `;`.

## Related issues

related to https://github.com/jwulf/connector-sdk/pull/1
