### PR TITLE
Add docker build and liniting to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,11 +13,28 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java-version }}
         cache: 'maven'
-    - name: Build
+
+    - name: Build Maven Artifacts
       run: mvn verify -PcheckFormat
+
+    - name: Lint Job Worker Runtime Dockerfile
+      uses: hadolint/hadolint-action@v2.0.0
+      with:
+        dockerfile: ./runtime-job-worker/Dockerfile
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build Job Worker Runtime Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: runtime-job-worker/
+        push: false
+        tags: camunda/connectors:local

--- a/runtime-job-worker/Dockerfile
+++ b/runtime-job-worker/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17-jre
 RUN mkdir /opt/app
 
-ADD target/connector-runtime-job-worker-*-with-dependencies.jar /opt/app
+COPY target/connector-runtime-job-worker-*-with-dependencies.jar /opt/app
 
 # Using entry point to allow downstream images to add JVM arguments using CMD
 ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.jobworker.Main"]


### PR DESCRIPTION
## Description

- ensure we can build the docker image during CI
- lint dockerfile for best practies using hadolint
- use COPY instead of ADD to add local files as recommend by hadolint
