### PR TITLE
fix(runtime): use object mapper to convert to map

### DIFF
--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
@@ -17,6 +17,7 @@
 package io.camunda.connector.runtime.jobworker.impl.feel;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import java.util.HashMap;
@@ -31,6 +32,8 @@ public class FeelEngineWrapper {
   static final String RESPONSE_MAP_KEY = "response";
   static final String ERROR_VARIABLES_MUST_NOT_BE_NULL = "variables cannot be null";
   static final String ERROR_EXPRESSION_EVALUATION_FAILED = "expression evaluation failed";
+  public static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
+      new TypeReference<>() {};
 
   private final FeelEngine feelEngine;
   private final ObjectMapper objectMapper;
@@ -64,10 +67,9 @@ public class FeelEngineWrapper {
     return scala.collection.immutable.Map.from(CollectionConverters.asScala(context));
   }
 
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> ensureVariablesMap(final Object variables) {
-    return (Map<String, Object>)
-        Objects.requireNonNull(variables, ERROR_VARIABLES_MUST_NOT_BE_NULL);
+  private Map<String, Object> ensureVariablesMap(final Object variables) {
+    Objects.requireNonNull(variables, ERROR_VARIABLES_MUST_NOT_BE_NULL);
+    return objectMapper.convertValue(variables, MAP_TYPE_REFERENCE);
   }
 
   public String evaluateToJson(final String expression, final Object variables) {

--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
@@ -32,8 +32,8 @@ public class FeelEngineWrapper {
   static final String RESPONSE_MAP_KEY = "response";
   static final String ERROR_VARIABLES_MUST_NOT_BE_NULL = "variables cannot be null";
   static final String ERROR_EXPRESSION_EVALUATION_FAILED = "expression evaluation failed";
-  public static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE =
-      new TypeReference<>() {};
+
+  static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {};
 
   private final FeelEngine feelEngine;
   private final ObjectMapper objectMapper;

--- a/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/api/outbound/ConnectorJobHandlerTest.java
+++ b/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/api/outbound/ConnectorJobHandlerTest.java
@@ -115,6 +115,25 @@ public class ConnectorJobHandlerTest {
     }
 
     @Test
+    public void shouldSetToResultExpressionWhenPojoIsReturned() {
+      // given
+      // Response from service -> {"callStatus":{"statusCode":"200 OK"}}
+      final String responseValue = "response";
+      var jobHandler =
+          new ConnectorJobHandler((context) -> new TestConnectorResponsePojo(responseValue));
+
+      // FEEL expression -> {"processedOutput":response.callStatus}
+      final String resultExpression = "{\"processedOutput\": response.value }";
+
+      // when
+      var result =
+          JobBuilder.create().withResultExpressionHeader(resultExpression).execute(jobHandler);
+
+      // then
+      assertThat(result.getVariables()).isEqualTo(Map.of("processedOutput", responseValue));
+    }
+
+    @Test
     public void shouldSetBothResultVariableAndExpression() {
       // given
       // Response from service -> {"callStatus":{"statusCode":"200 OK"}}
@@ -211,6 +230,18 @@ public class ConnectorJobHandlerTest {
     @Override
     public SecretProvider getSecretProvider() {
       return name -> TestSecretProvider.SECRET_NAME.equals(name) ? "baz" : null;
+    }
+  }
+
+  private static class TestConnectorResponsePojo {
+    private final String value;
+
+    private TestConnectorResponsePojo(final String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
     }
   }
 }

--- a/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapperExpressionEvaluationTest.java
+++ b/runtime-job-worker/src/test/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapperExpressionEvaluationTest.java
@@ -50,6 +50,21 @@ class FeelEngineWrapperExpressionEvaluationTest {
   }
 
   @Test
+  void evaluateToJson_ShouldSucceed_WhenHandlingPojo() {
+    // given
+    final var resultExpression = "= { value: response.value, response: response }";
+    final var variables = new TestPojo("FOO");
+
+    // when
+    final String evaluatedResultAsJson =
+        objectUnderTest.evaluateToJson(resultExpression, variables);
+
+    // then
+    assertThat(evaluatedResultAsJson)
+        .isEqualTo("{\"response\":{\"value\":\"FOO\"},\"value\":\"FOO\"}");
+  }
+
+  @Test
   void evaluateToJson_ShouldSucceed_WhenExpressionStartsWithEqualsSign() {
     // given
     // FEEL expression -> ={"processedOutput":response.callStatus}
@@ -146,5 +161,18 @@ class FeelEngineWrapperExpressionEvaluationTest {
 
     // then
     assertThat(e.getMessage()).contains(FeelEngineWrapper.ERROR_EXPRESSION_EVALUATION_FAILED);
+  }
+
+  class TestPojo {
+
+    private String value;
+
+    public TestPojo(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
   }
 }


### PR DESCRIPTION
## Description

To support POJO responses of the connector function use the jackson object mapper to ensure that response can be casted to a map.

## Related issues

closes #135 

