### PR TITLE
Ignore unknown object values in response

### DIFF
--- a/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
+++ b/runtime-job-worker/src/main/java/io/camunda/connector/runtime/jobworker/impl/feel/FeelEngineWrapper.java
@@ -19,6 +19,7 @@ package io.camunda.connector.runtime.jobworker.impl.feel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule$;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +45,10 @@ public class FeelEngineWrapper {
             .valueMapper(SpiServiceLoader.loadValueMapper())
             .functionProvider(SpiServiceLoader.loadFunctionProvider())
             .build(),
-        new ObjectMapper().registerModule(DefaultScalaModule$.MODULE$));
+        new ObjectMapper()
+            .registerModule(DefaultScalaModule$.MODULE$)
+            // deserialize unknown types as empty objects
+            .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS));
   }
 
   public FeelEngineWrapper(final FeelEngine feelEngine, final ObjectMapper objectMapper) {


### PR DESCRIPTION
## Description

This PR ignores fields of a response, which are not know types for the object mapper. I decided to ignore them to gracefully handle the response instead of failing.

- Add test to verify null values are handled correctly
- Add test to verify unknown object values are ignore

## Related issues

related to #153 

