### PR TITLE
chore: add more supported third-party licenses

### DIFF
--- a/licenses/third-party.ftl
+++ b/licenses/third-party.ftl
@@ -17,8 +17,12 @@
     <#return "https://opensource.org/licenses/BSD-3-Clause">
   <#elseif license == "EPL-2.0">
     <#return "https://www.eclipse.org/legal/epl-2.0/">
+  <#elseif license == "EPL-1.0">
+    <#return "https://www.eclipse.org/legal/epl-v10.html">
   <#elseif license == "GPLv2 with Classpath Exception">
     <#return "https://www.gnu.org/software/classpath/license.html">
+  <#elseif license == "GNU Lesser General Public License, Version 2.1">
+    <#return "http://www.gnu.org/licenses/lgpl-2.1.html">
   <#elseif license == "CDDLv1.0">
     <#return "https://opensource.org/licenses/CDDL-1.0">
   <#elseif license == "CDDLv1.1">

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -372,11 +372,13 @@ limitations under the License.</license.inlineheader>
           <version>${plugin.version.license.codehaus}</version>
           <configuration>
             <licenseMerges>
-              <licenseMerge>Apache-2.0|Apache License 2.0|Apache License, Version 2.0|The Apache Software License, Version 2.0|Apache 2.0|Apache License, version 2.0|The Apache License, Version 2.0|Apache 2</licenseMerge>
+              <licenseMerge>Apache-2.0|Apache License 2.0|Apache License, Version 2.0|The Apache Software License, Version 2.0|Apache 2.0|Apache License, version 2.0|The Apache License, Version 2.0|Apache 2|Apache License</licenseMerge>
               <licenseMerge>MIT|MIT License|The MIT License|MIT license|The MIT License (MIT)</licenseMerge>
               <licenseMerge>BSD-3-Clause|3-Clause BSD License|BSD|BSD New license</licenseMerge>
-              <licenseMerge>EPL-2.0|Eclipse Public License v. 2.0</licenseMerge>
-              <licenseMerge>GPLv2 with Classpath Exception|GNU General Public License, version 2 with the GNU Classpath Exception</licenseMerge>
+              <licenseMerge>EPL-1.0|Eclipse Public License - v 1.0|Eclipse Public License v. 1.0</licenseMerge>
+              <licenseMerge>EPL-2.0|Eclipse Public License v. 2.0|EPL 2.0</licenseMerge>
+              <licenseMerge>GPLv2 with Classpath Exception|GPL2 w/ CPE|GNU General Public License, version 2 with the GNU Classpath Exception</licenseMerge>
+              <licenseMerge>GNU Lesser General Public License, Version 2.1|GNU Lesser General Public License</licenseMerge>
               <licenseMerge>CDDLv1.0|COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</licenseMerge>
               <licenseMerge>Bouncy Castle|Bouncy Castle Licence</licenseMerge>
             </licenseMerges>


### PR DESCRIPTION
## Description

Adds support for the following licenses in our TPL file:

* Apache License
* Eclipse Public License v. 1.0
* EPL-1.0
* Eclipse Public License - v 1.0
* EPL 2.0
* GNU Lesser General Public License, Version 2.1
* GNU Lesser General Public License

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #207