### PR TITLE
docs: fix broken link to `runtime`

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -31,7 +31,7 @@ public class PingConnector implements ConnectorFunction {
 
 It exposes itself as a [`ConnectorFunction` SPI implementation](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
 
-Connector run-times, e.g. [job worker run-time](../runtime-job-worker) wrap the function to execute it in various environments.
+Connector run-times, e.g. [job worker run-time](../runtime) wrap the function to execute it in various environments.
 
 
 ## Build


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR fixes the broken link in [`./core/README.md`](https://github.com/camunda/connector-sdk/blob/c3e7b0828458774660a97ec6033295d74547841e/core/README.md?plain=1#L34). The reason of the problem is the same as described in PR #211 (I did not spot it then).

## Related issues

<!-- Which issues are closed by this PR or are related -->
There no related issue.
