### PR TITLE
docs: add missing `.` in `ValidationProvider` link

### DIFF
--- a/validation/README.md
+++ b/validation/README.md
@@ -115,7 +115,7 @@ If you want to provide your own implementation, you can exclude those two from t
 
 ## Custom validation
 
-If you want to provide your own validation implementation instead of the `connector-validation`, you need to implement the [ValidationProvider](./core/src/main/java/io/camunda/connector/api/validation/ValidationProvider.java) and provide it as an SPI.
+If you want to provide your own validation implementation instead of the `connector-validation`, you need to implement the [ValidationProvider](../core/src/main/java/io/camunda/connector/api/validation/ValidationProvider.java) and provide it as an SPI.
 
 ```java
 public class MyValidationProviderImpl implements ValidationProvider {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
This PR fixes the dead link in [`./validation/README.md`](https://github.com/camunda/connector-sdk/blob/d278f8be151c2ef7b08f56a5bda09d6b592ebcd8/validation/README.md?plain=1#L118).

## Related issues

<!-- Which issues are closed by this PR or are related -->
There is no related issue.

