### PR TITLE
Add secret handling for inbound connectors

### DIFF
--- a/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
+++ b/core/src/main/java/io/camunda/connector/api/inbound/InboundConnectorContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.api.inbound;
+
+import io.camunda.connector.api.secret.SecretStore;
+
+/**
+ * The context object provided to an inbound connector function. The context allows to fetch
+ * information injected by the environment runtime.
+ */
+public interface InboundConnectorContext {
+
+  /**
+   * Fetches the secret store that is provided by the environment. You can use this to create your
+   * own secret replacement routines.
+   *
+   * @return the secret store provided by the environment
+   */
+  SecretStore getSecretStore();
+
+  /**
+   * Replaces the secrets in the input object by the defined secrets in the context's secret store.
+   *
+   * @param input - the object to replace secrets in
+   */
+  void replaceSecrets(Object input);
+
+  /**
+   * Validates the input object
+   *
+   * @param input - the object to validate
+   */
+  void validate(Object input);
+}

--- a/core/src/main/java/io/camunda/connector/impl/context/AbstractConnectorContext.java
+++ b/core/src/main/java/io/camunda/connector/impl/context/AbstractConnectorContext.java
@@ -14,24 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.impl.outbound;
+package io.camunda.connector.impl.context;
 
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.secret.SecretStore;
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.impl.secret.SecretHandler;
 import java.util.ServiceLoader;
 
-public abstract class AbstractOutboundConnectorContext implements OutboundConnectorContext {
+public abstract class AbstractConnectorContext {
 
-  private SecretHandler secretHandler;
+  protected SecretHandler secretHandler;
+  protected final SecretStore secretStore;
 
-  @Override
-  public void validate(Object input) {
-    getValidationProvider().validate(input);
+  protected AbstractConnectorContext(final SecretStore secretStore) {
+    if (secretStore == null) {
+      throw new RuntimeException("Secret store was not provided");
+    }
+    this.secretStore = secretStore;
   }
 
-  @Override
-  public void replaceSecrets(Object input) {
+  public void replaceSecrets(final Object input) {
     getSecretHandler().handleSecretContainer(input, getSecretHandler());
   }
 
@@ -40,6 +42,14 @@ public abstract class AbstractOutboundConnectorContext implements OutboundConnec
       secretHandler = new SecretHandler(getSecretStore());
     }
     return secretHandler;
+  }
+
+  public SecretStore getSecretStore() {
+    return secretStore;
+  }
+
+  public void validate(Object input) {
+    getValidationProvider().validate(input);
   }
 
   /**

--- a/core/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
+++ b/core/src/main/java/io/camunda/connector/test/inbound/InboundConnectorContextBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.test.inbound;
+
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.api.secret.SecretProvider;
+import io.camunda.connector.api.secret.SecretStore;
+import io.camunda.connector.impl.context.AbstractConnectorContext;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InboundConnectorContextBuilder {
+  protected final Map<String, String> secrets = new HashMap<>();
+  protected SecretProvider secretProvider = secrets::get;
+  protected SecretStore secretStore = new SecretStore(secretProvider);
+
+  public static InboundConnectorContextBuilder create() {
+    return new InboundConnectorContextBuilder();
+  }
+
+  /**
+   * Provides the secret's value for the given name.
+   *
+   * @param name - the secret's name, e.g. MY_SECRET when referred to as "secrets.MY_SECRET"
+   * @param value - the secret's value
+   * @return builder for fluent API
+   */
+  public InboundConnectorContextBuilder secret(String name, String value) {
+    secrets.put(name, value);
+    return this;
+  }
+
+  /**
+   * Provides the secret values via the defined {@link SecretProvider}.
+   *
+   * @param secretProvider - provider for secret values, given a secret name
+   * @return builder for fluent API
+   */
+  public InboundConnectorContextBuilder secrets(SecretProvider secretProvider) {
+    this.secretProvider = secretProvider;
+    return this;
+  }
+
+  /**
+   * Provides the secret values via the defined {@link SecretStore}.
+   *
+   * @param secretStore - secret store
+   * @return builder for fluent API
+   */
+  public InboundConnectorContextBuilder secrets(SecretStore secretStore) {
+    this.secretStore = secretStore;
+    return this;
+  }
+
+  /**
+   * @return the {@link io.camunda.connector.api.inbound.InboundConnectorContext} including all
+   *     previously defined properties
+   */
+  public InboundConnectorContextBuilder.TestInboundConnectorContext build() {
+    return new InboundConnectorContextBuilder.TestInboundConnectorContext(secretStore);
+  }
+
+  public class TestInboundConnectorContext extends AbstractConnectorContext
+      implements InboundConnectorContext {
+    private SecretStore secretStore;
+
+    protected TestInboundConnectorContext(SecretStore secretStore) {
+      super(secretStore);
+    }
+
+    @Override
+    public SecretStore getSecretStore() {
+      if (secretStore == null) {
+        secretStore = new SecretStore(System::getenv);
+      }
+      return secretStore;
+    }
+  }
+}

--- a/inbound/src/main/java/io/camunda/connector/inbound/webhook/WebhookConnectorProperties.java
+++ b/inbound/src/main/java/io/camunda/connector/inbound/webhook/WebhookConnectorProperties.java
@@ -16,15 +16,33 @@
  */
 package io.camunda.connector.inbound.webhook;
 
+import io.camunda.connector.api.annotation.Secret;
 import io.camunda.connector.inbound.registry.InboundConnectorProperties;
 import io.camunda.connector.inbound.security.signature.HMACSwitchCustomerChoice;
 
 public class WebhookConnectorProperties {
 
-  public InboundConnectorProperties genericProperties;
+  private final InboundConnectorProperties genericProperties;
+  @Secret private String context;
+  private String activationCondition;
+  private String variableMapping;
+  private String shouldValidateHmac;
+  @Secret private String hmacSecret;
+  @Secret private String hmacHeader;
+  private String hmacAlgorithm;
 
   public WebhookConnectorProperties(InboundConnectorProperties properties) {
     this.genericProperties = properties;
+    this.context = readProperty("inbound.context");
+    this.activationCondition = readProperty("inbound.activationCondition");
+    this.variableMapping = readProperty("inbound.variableMapping");
+    this.shouldValidateHmac =
+        genericProperties
+            .getProperties()
+            .getOrDefault("inbound.shouldValidateHmac", HMACSwitchCustomerChoice.disabled.name());
+    this.hmacSecret = genericProperties.getProperties().get("inbound.hmacSecret");
+    this.hmacHeader = genericProperties.getProperties().get("inbound.hmacHeader");
+    this.hmacAlgorithm = genericProperties.getProperties().get("inbound.hmacAlgorithm");
   }
 
   public String getConnectorIdentifier() {
@@ -48,38 +66,65 @@ public class WebhookConnectorProperties {
   }
 
   public String getContext() {
-    return readProperty("inbound.context");
+    return context;
+  }
+
+  public void setContext(String context) {
+    this.context = context;
   }
 
   public String getActivationCondition() {
-    return readProperty("inbound.activationCondition");
+    return activationCondition;
+  }
+
+  public void setActivationCondition(String activationCondition) {
+    this.activationCondition = activationCondition;
   }
 
   public String getVariableMapping() {
-    return readProperty("inbound.variableMapping");
+    return variableMapping;
   }
 
-  // Security / HMAC Validation
+  public void setVariableMapping(String variableMapping) {
+    this.variableMapping = variableMapping;
+  }
 
   // Dropdown that indicates whether customer wants to validate webhook request with HMAC. Values:
   // enabled | disabled
-  public String shouldValidateHMAC() {
-    return genericProperties
-        .getProperties()
-        .getOrDefault("inbound.shouldValidateHmac", HMACSwitchCustomerChoice.disabled.name());
+  public String getShouldValidateHmac() {
+    return shouldValidateHmac;
   }
+
+  public void setShouldValidateHmac(String shouldValidateHmac) {
+    this.shouldValidateHmac = shouldValidateHmac;
+  }
+
   // HMAC secret token. An arbitrary String, example 'mySecretToken'
-  public String getHMACSecret() {
-    return genericProperties.getProperties().get("inbound.hmacSecret");
+  public String getHmacSecret() {
+    return hmacSecret;
   }
+
+  public void setHmacSecret(String hmacSecret) {
+    this.hmacSecret = hmacSecret;
+  }
+
   // Indicates which header is used to store HMAC signature. Example, X-Hub-Signature-256
-  public String getHMACHeader() {
-    return genericProperties.getProperties().get("inbound.hmacHeader");
+  public String getHmacHeader() {
+    return hmacHeader;
   }
+
+  public void setHmacHeader(String hmacHeader) {
+    this.hmacHeader = hmacHeader;
+  }
+
   // Indicates which algorithm was used to produce HMAC signature. Should correlate enum names of
   // io.camunda.connector.inbound.security.signature.HMACAlgoCustomerChoice
-  public String getHMACAlgo() {
-    return genericProperties.getProperties().get("inbound.hmacAlgorithm");
+  public String getHmacAlgorithm() {
+    return hmacAlgorithm;
+  }
+
+  public void setHmacAlgorithm(String hmacAlgorithm) {
+    this.hmacAlgorithm = hmacAlgorithm;
   }
 
   public String getBpmnProcessId() {

--- a/inbound/src/test/java/io/camunda/connector/inbound/WebhookControllerPlainJavaTests.java
+++ b/inbound/src/test/java/io/camunda/connector/inbound/WebhookControllerPlainJavaTests.java
@@ -17,17 +17,21 @@
 package io.camunda.connector.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.inbound.registry.InboundConnectorProperties;
 import io.camunda.connector.inbound.registry.InboundConnectorRegistry;
 import io.camunda.connector.inbound.webhook.InboundWebhookRestController;
 import io.camunda.connector.inbound.webhook.WebhookConnectorProperties;
 import io.camunda.connector.inbound.webhook.WebhookResponse;
 import io.camunda.connector.runtime.util.feel.FeelEngineWrapper;
+import io.camunda.connector.test.inbound.InboundConnectorContextBuilder;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
@@ -52,11 +56,13 @@ public class WebhookControllerPlainJavaTests {
   @Test
   public void multipleWebhooksOnSameContextPath() throws IOException {
     InboundConnectorRegistry registry = new InboundConnectorRegistry();
+    InboundConnectorContext connectorContext =
+        InboundConnectorContextBuilder.create().secret("DUMMY_SECRET", "s3cr3T").build();
     ZeebeClient zeebeClient = mock(ZeebeClient.class);
     when(zeebeClient.newCreateInstanceCommand()).thenReturn(new CreateCommandDummy());
     InboundWebhookRestController controller =
         new InboundWebhookRestController(
-            registry, zeebeClient, new FeelEngineWrapper(), new ObjectMapper());
+            registry, connectorContext, zeebeClient, new FeelEngineWrapper(), new ObjectMapper());
 
     registry.reset();
     // registry.markProcessDefinitionChecked(123, "processA", 1);

--- a/inbound/src/test/java/io/camunda/connector/inbound/webhook/InboundWebhookRestControllerTest.java
+++ b/inbound/src/test/java/io/camunda/connector/inbound/webhook/InboundWebhookRestControllerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.inbound.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
+import io.camunda.connector.inbound.registry.InboundConnectorProperties;
+import io.camunda.connector.inbound.registry.InboundConnectorRegistry;
+import io.camunda.connector.inbound.security.signature.HMACSwitchCustomerChoice;
+import io.camunda.connector.runtime.util.feel.FeelEngineWrapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+class InboundWebhookRestControllerTest {
+
+  private static final String DEFAULT_CONTEXT = "contextPath";
+  private static final byte[] DEFAULT_REQUEST_BODY =
+      "{\"key\":\"value\"}".getBytes(StandardCharsets.UTF_8);
+  private static final Map<String, String> DEFAULT_HEADERS = Map.of("x-signature", "sha1=aabbccdd");
+
+  @Mock private InboundConnectorRegistry registry;
+  @Mock private InboundConnectorContext connectorContext;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private ZeebeClient zeebeClient;
+
+  @Mock private FeelEngineWrapper feelEngine;
+  @Spy private ObjectMapper jsonMapper;
+
+  @InjectMocks private InboundWebhookRestController controller;
+
+  @Test
+  void inbound_HappyCase_ReturnsExecutedConnectorMessage() throws IOException {
+    final String evaluationExpression = "=a=b";
+    final String variablesMapping = "={x: response.key}";
+    InboundConnectorProperties connectorProps =
+        new InboundConnectorProperties(
+            "proc-id",
+            1,
+            2,
+            Map.of(
+                "inbound.context", DEFAULT_CONTEXT,
+                "inbound.activationCondition", evaluationExpression,
+                "inbound.variableMapping", variablesMapping,
+                "inbound.shouldValidateHmac", HMACSwitchCustomerChoice.disabled.name()));
+    WebhookConnectorProperties props = new WebhookConnectorProperties(connectorProps);
+    when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(true);
+    when(registry.getWebhookConnectorByContextPath(DEFAULT_CONTEXT)).thenReturn(List.of(props));
+    when(feelEngine.evaluate(eq(evaluationExpression), any(Map.class))).thenReturn(true);
+    when(feelEngine.evaluate(eq(variablesMapping), any(Map.class))).thenReturn(Map.of());
+
+    ResponseEntity<WebhookResponse> response =
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+
+    verify(connectorContext).replaceSecrets(props);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getUnauthorizedConnectors()).isEmpty();
+    assertThat(response.getBody().getExecutedConnectors()).isNotEmpty();
+    assertThat(response.getBody().getExecutedConnectors())
+        .containsKey(props.getConnectorIdentifier());
+    assertThat(response.getBody().getUnactivatedConnectors()).isEmpty();
+  }
+
+  @Test
+  void inbound_RegistryHasNoContextPath_ThrowsNotFoundException() {
+    when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(false);
+    assertThrows(
+        ResponseStatusException.class,
+        () -> controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS));
+  }
+
+  @Test
+  void inbound_HmacValidationFailed_ReturnsUnauthorizedConnectorMessage() throws IOException {
+    InboundConnectorProperties connectorProps =
+        new InboundConnectorProperties(
+            "proc-id",
+            1,
+            2,
+            Map.of(
+                "inbound.context", DEFAULT_CONTEXT,
+                "inbound.activationCondition", "",
+                "inbound.variableMapping", "",
+                "inbound.shouldValidateHmac", HMACSwitchCustomerChoice.enabled.name(),
+                "inbound.hmacSecret", "",
+                "inbound.hmacHeader", "hmac-header",
+                "inbound.hmacAlgorithm", "sha_256"));
+    WebhookConnectorProperties props = new WebhookConnectorProperties(connectorProps);
+    when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(true);
+    when(registry.getWebhookConnectorByContextPath(DEFAULT_CONTEXT)).thenReturn(List.of(props));
+
+    ResponseEntity<WebhookResponse> response =
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+
+    verify(connectorContext).replaceSecrets(props);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getUnauthorizedConnectors()).isNotEmpty();
+    assertThat(response.getBody().getUnauthorizedConnectors())
+        .contains(props.getConnectorIdentifier());
+    assertThat(response.getBody().getExecutedConnectors()).isEmpty();
+    assertThat(response.getBody().getUnactivatedConnectors()).isEmpty();
+  }
+
+  @Test
+  void inbound_ActivationConditionFailed_ReturnsUnactivatedConnectorMessage() throws IOException {
+    final String evaluationExpression = "=a=b";
+    InboundConnectorProperties connectorProps =
+        new InboundConnectorProperties(
+            "proc-id",
+            1,
+            2,
+            Map.of(
+                "inbound.context",
+                DEFAULT_CONTEXT,
+                "inbound.activationCondition",
+                evaluationExpression,
+                "inbound.variableMapping",
+                "",
+                "inbound.shouldValidateHmac",
+                HMACSwitchCustomerChoice.disabled.name()));
+    WebhookConnectorProperties props = new WebhookConnectorProperties(connectorProps);
+    when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(true);
+    when(registry.getWebhookConnectorByContextPath(DEFAULT_CONTEXT)).thenReturn(List.of(props));
+    when(feelEngine.evaluate(anyString(), any(Map.class))).thenReturn(false);
+
+    ResponseEntity<WebhookResponse> response =
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+
+    verify(connectorContext).replaceSecrets(props);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getUnauthorizedConnectors()).isEmpty();
+    assertThat(response.getBody().getExecutedConnectors()).isEmpty();
+    assertThat(response.getBody().getUnactivatedConnectors()).isNotEmpty();
+    assertThat(response.getBody().getUnactivatedConnectors())
+        .contains(props.getConnectorIdentifier());
+  }
+
+  @Test
+  void inbound_ExceptionThrown_ReturnsExceptionConnectorMessage() throws IOException {
+    final String evaluationExpression = "=a=b";
+    InboundConnectorProperties connectorProps =
+        new InboundConnectorProperties(
+            "proc-id",
+            1,
+            2,
+            Map.of(
+                "inbound.context",
+                DEFAULT_CONTEXT,
+                "inbound.activationCondition",
+                evaluationExpression,
+                "inbound.variableMapping",
+                "",
+                "inbound.shouldValidateHmac",
+                HMACSwitchCustomerChoice.disabled.name()));
+    WebhookConnectorProperties props = new WebhookConnectorProperties(connectorProps);
+    when(registry.containsContextPath(DEFAULT_CONTEXT)).thenReturn(true);
+    when(registry.getWebhookConnectorByContextPath(DEFAULT_CONTEXT)).thenReturn(List.of(props));
+
+    final String exceptionMessage = "Something went wrong";
+    when(feelEngine.evaluate(anyString(), any(Map.class)))
+        .thenThrow(new RuntimeException(exceptionMessage));
+
+    ResponseEntity<WebhookResponse> response =
+        controller.inbound(DEFAULT_CONTEXT, DEFAULT_REQUEST_BODY, DEFAULT_HEADERS);
+
+    verify(connectorContext).replaceSecrets(props);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getUnauthorizedConnectors()).isEmpty();
+    assertThat(response.getBody().getExecutedConnectors()).isEmpty();
+    assertThat(response.getBody().getUnactivatedConnectors()).isEmpty();
+    assertThat(response.getBody().getErrors()).isNotEmpty();
+    assertThat(response.getBody().getErrors())
+        .contains(props.getConnectorIdentifier() + ">" + exceptionMessage);
+  }
+}

--- a/runtime-util/pom.xml
+++ b/runtime-util/pom.xml
@@ -71,6 +71,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>

--- a/runtime-util/src/main/java/io/camunda/connector/runtime/util/inbound/InboundJobHandlerContext.java
+++ b/runtime-util/src/main/java/io/camunda/connector/runtime/util/inbound/InboundJobHandlerContext.java
@@ -14,35 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.connector.runtime.util.outbound;
+package io.camunda.connector.runtime.util.inbound;
 
-import io.camunda.connector.api.outbound.OutboundConnectorContext;
+import io.camunda.connector.api.inbound.InboundConnectorContext;
 import io.camunda.connector.api.secret.SecretStore;
 import io.camunda.connector.impl.context.AbstractConnectorContext;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
 
-/**
- * Implementation of {@link io.camunda.connector.api.outbound.OutboundConnectorContext} passed on to
- * a {@link io.camunda.connector.api.outbound.OutboundConnectorFunction} when called from the {@link
- * ConnectorJobHandler}.
- */
-public class JobHandlerContext extends AbstractConnectorContext
-    implements OutboundConnectorContext {
+/** Implementation of {@link io.camunda.connector.api.inbound.InboundConnectorContext} */
+public class InboundJobHandlerContext extends AbstractConnectorContext
+    implements InboundConnectorContext {
 
-  private final ActivatedJob job;
-
-  public JobHandlerContext(final ActivatedJob job, final SecretStore secretStore) {
+  public InboundJobHandlerContext(final SecretStore secretStore) {
     super(secretStore);
-    this.job = job;
-  }
-
-  @Override
-  public <T> T getVariablesAsType(Class<T> cls) {
-    return job.getVariablesAsType(cls);
-  }
-
-  @Override
-  public String getVariables() {
-    return job.getVariables();
   }
 }

--- a/runtime-util/src/test/java/io/camunda/connector/runtime/util/inbound/InboundJobHandlerContextTest.java
+++ b/runtime-util/src/test/java/io/camunda/connector/runtime/util/inbound/InboundJobHandlerContextTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.connector.runtime.util.inbound;
+
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import io.camunda.connector.api.secret.SecretStore;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboundJobHandlerContextTest {
+
+  private InboundJobHandlerContext testObject;
+  @Mock private SecretStore secretStore;
+
+  @BeforeEach
+  void beforeEach() {
+    testObject = new InboundJobHandlerContext(secretStore);
+  }
+
+  @Test
+  void constructor_NormalInitialization() {
+    Assertions.assertThat(testObject.getSecretStore()).isSameAs(secretStore);
+  }
+
+  @Test
+  void constructor_InitializationWithNullSecretStore_RaisesException() {
+    assertThrowsExactly(RuntimeException.class, () -> new InboundJobHandlerContext(null));
+  }
+}

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>spring-zeebe-starter</artifactId>
-    </dependency>    
+    </dependency>
 
     <!-- Test -->
     <dependency>


### PR DESCRIPTION
## Description

Add secret handling for inbound connectors.

## Testing done

### Inbound

- Run the latest https://github.com/camunda/camunda-platform: `docker-compose -f docker-compose-core.yaml up`
- Disable running connector bundle (via Docker Desktop)
- Build the latest SDK `mvn clean package install`
- Build the latest connector with SDK (e.g., SQS)
- Put both jars with dependencies into same directory
- Export secret as environment variable, e.g. `export HMAC_SECRET='mySecretKey'`
- Run:

```
java -cp 'runtime.jar:sqs.jar' \ 
  -Dserver.port=9898 \
  -Dzeebe.client.broker.gateway-address=127.0.0.1:26500 \
  -Dzeebe.client.security.plaintext=true \
  -Dcamunda.connector.polling.enabled=true \
  -Dcamunda.connector.webhook.enabled=true \
  -Dcamunda.operate.client.url=http://localhost:8081 \
  -Dcamunda.operate.client.username=demo \
  -Dcamunda.operate.client.password=demo \
  -Dspring.main.web-application-type=servlet \
    io.camunda.connector.runtime.ConnectorRuntimeApplication
```

- Deploy arbitrary inbound connector
- Execute, e.g. `curl -XPOST -H 'Content-Type: application/json' -H "X-Hub-Signature-256: sha256=98ae3cdd258e3f7e7334d7963c779237392d05d32e991a167f3943e9f8747de2" localhost:9898/inbound/github_webhook_secret2  --data @example/webhook-payload-activates-packed.json`

See result: `{"unauthorizedConnectors":[],"unactivatedConnectors":[],"executedConnectors":{"webhook-github_webhook_secret2-Process_1vcyhar-2":{"processDefinitionKey":2251799813686654,"bpmnProcessId":"Process_1vcyhar","version":2,"processInstanceKey":2251799813686777}},"errors":[]}`

### Outbound

Normal regression testing for SQS.

closes #194

