### PR TITLE
chore(runtime): include validation module

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>connector-runtime-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.camunda.connector</groupId>
+      <artifactId>connector-validation</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>spring-zeebe-starter</artifactId>
     </dependency>    


### PR DESCRIPTION
## Description

Includes the validation module by default in the `runtime`. This provides the module so Connectors can consume it if they want to. Connectors (optionally) depend on the validation module with scope `provided`. Thus, as their runtime, we need to provide it here.

## Related issues

related to https://github.com/camunda/team-connectors/issues/209

