### PR TITLE
feat!: move to Jakarta Bean Validaton 2.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,13 +75,13 @@ limitations under the License.</license.inlineheader>
     <!-- Third party dependencies -->
     <version.spring-boot>2.7.5</version.spring-boot>
     <version.slf4j>1.7.36</version.slf4j>
-    <version.jakarta-validation>3.0.2</version.jakarta-validation>
+    <version.jakarta-validation>2.0.2</version.jakarta-validation>
     <version.gson>2.10</version.gson>
     <version.mockito>4.8.1</version.mockito>
     <version.junit-jupiter>5.9.1</version.junit-jupiter>
     <version.assertj>3.23.1</version.assertj>
     <version.jackson-module-scala>2.13.4</version.jackson-module-scala>
-    <version.hibernate-validator>8.0.0.Final</version.hibernate-validator>
+    <version.hibernate-validator>6.2.5.Final</version.hibernate-validator>
 
     <!-- maven plugins (not managed by parent) -->
     <plugin.version.function-maven-plugin>0.10.1</plugin.version.function-maven-plugin>

--- a/validation/README.md
+++ b/validation/README.md
@@ -6,12 +6,12 @@ Default implementation for the [ValdationProvider](../core/src/main/java/io/camu
 
 Adding this module as a dependency makes the [DefaultValidationProvider](./src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java) discoverable via SPI in the SDK core.
 
-Then, you can use [Jakarta Bean Validation Constraints](https://jakarta.ee/specifications/bean-validation/3.0/apidocs/jakarta/validation/constraints/package-summary.html) on your Connector's input objects.
+Then, you can use [Jakarta Bean Validation Constraints](https://jakarta.ee/specifications/bean-validation/2.0/apidocs/javax/validation/constraints/package-summary.html) on your Connector's input objects.
 
 ```java
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 
 public class PingRequest {
   @NotEmpty
@@ -47,13 +47,13 @@ public class PingConnector implements OutboundConnectorFunction {
 ## Constraint message interpolation
 
 By default, the validation module uses Hibernate Validator's
-[ParameterMessageInterpolator](https://docs.jboss.org/hibernate/stable/validator/api/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.html).
-This allows using message parameters in contraint messages, like in the following example:
+[ParameterMessageInterpolator](https://docs.jboss.org/hibernate/validator/6.2/api/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.html).
+This allows using message parameters in constraint messages, like in the following example:
 
 ```java
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 
 public class PingRequest {
   @NotEmpty
@@ -68,65 +68,22 @@ public class PingRequest {
 ```
 
 The validation module does not support using expressions by default as described in the
-[Bean Validation API](https://jakarta.ee/specifications/bean-validation/3.0/jakarta-bean-validation-spec-3.0.html#validationapi-message).
-To enable expression support, add a dependency on an expression provider like the following
+[Bean Validation API](https://jakarta.ee/specifications/bean-validation/2.0/bean-validation_2.0.html#validationapi-message).
+To enable expression support, add a dependency on an expression provider like the following:
 
 ```xml
-  <dependency>
-    <groupId>org.glassfish.expressly</groupId>
-    <artifactId>expressly</artifactId>
-    <version>5.0.0</version>
-  </dependency>
-```
-
-## Replace Jakarta Bean Validation implementation
-
-This validation module uses [Hibernate Validator](https://hibernate.org/validator/) to provide an implementation of the Jakarta Bean Validation API.
-If you want to provide your own implementation, you can exclude those two from the dependency and add your own.
-
-```xml
-
-<dependencies>
-  ...
-  <dependency>
-    <groupId>io.camunda.connector</groupId>
-    <artifactId>connector-validation</artifactId>
-    <version>0.2.2</version>
-    <exclusions>
-      <exclusion>
-        <groupId>org.hibernate.validator</groupId>
-        <artifactId>hibernate-validator</artifactId>
-      </exclusion>
-    </exclusions>
-  </dependency>
-
-  <dependency>
-    <groupId>some.vendor</groupId>
-    <artifactId>some-validator-implementation</artifactId>
-  </dependency>
-
-  <dependency>
-    <groupId>some.vendor</groupId>
-    <artifactId>some-el-implementation</artifactId>
-  </dependency>
-  ...
-</dependencies>
+<dependency>
+  <groupId>org.glassfish</groupId>
+  <artifactId>jakarta.el</artifactId>
+  <version>3.0.4</version>
+  <scope>test</scope>
+</dependency>
 ```
 
 ## Custom validation
 
-If you want to provide your own validation implementation instead of the `connector-validation`, you need to implement the [ValidationProvider](../core/src/main/java/io/camunda/connector/api/validation/ValidationProvider.java) and provide it as an SPI.
-
-```java
-public class MyValidationProviderImpl implements ValidationProvider {
-  public void validate(Object objectToValidate) {
-    // do what you will
-    // throw an exception containing your validation result as message if something is wrong
-  }
-}
-```
-
-To provide this as an SPI, create a file `src/main/resources/META-INF/services/io.camunda.connector.api.validation.ValidationProvider` containing the fully qualified classname of your implementation, for example `org.myorg.validation.MyValidationProviderImpl`.
+You can provide your own validation implementation within your Connector.
+Trigger it from within your Connector function as needed and do not use `OutboundConnectorContext.validate`.
 
 ## Build
 

--- a/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
+++ b/validation/src/main/java/io/camunda/connector/validation/impl/DefaultValidationProvider.java
@@ -18,14 +18,14 @@ package io.camunda.connector.validation.impl;
 
 import io.camunda.connector.api.validation.ValidationProvider;
 import io.camunda.connector.impl.ConnectorInputException;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.MessageInterpolator;
-import jakarta.validation.Validation;
-import jakarta.validation.ValidationException;
-import jakarta.validation.ValidatorFactory;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.validation.ConstraintViolation;
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.ValidatorFactory;
 import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 
 public class DefaultValidationProvider implements ValidationProvider {
@@ -50,7 +50,7 @@ public class DefaultValidationProvider implements ValidationProvider {
 
   protected MessageInterpolator getMessageInterpolator() {
     try {
-      Class.forName("jakarta.el.ExpressionFactory");
+      Class.forName("javax.el.ExpressionFactory");
       // return null to use validator factory's default
       return null;
     } catch (Exception e) {

--- a/validation/src/test/java/io/camunda/connector/validation/User.java
+++ b/validation/src/test/java/io/camunda/connector/validation/User.java
@@ -16,12 +16,12 @@
  */
 package io.camunda.connector.validation;
 
-import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public class User {
 

--- a/validation/src/test/java/io/camunda/connector/validation/ValidationProviderTest.java
+++ b/validation/src/test/java/io/camunda/connector/validation/ValidationProviderTest.java
@@ -51,8 +51,8 @@ class ValidationProviderTest {
     // then
     assertThat(exception)
         .isInstanceOf(ConnectorInputException.class)
-        .hasMessageStartingWith(
-            "jakarta.validation.ValidationException: Found constraints violated while validating input:")
+        .hasMessageContaining(
+            "ValidationException: Found constraints violated while validating input:")
         .hasMessageContaining("- working:")
         .hasMessageContaining("- email: Email should be valid")
         .hasMessageContaining("- age: Age should not be greater than 150");


### PR DESCRIPTION
## Description

Moves from Bean Validation 3.0 to version 2.0 for better compatibility with current Java ecosystem, e.g. Spring 5 and Spring Boot 2.

BREAKING CHANGE: All validation annotations have to be renamed from `jakarta.validation.*` to `javax.validation.*`. This applies to all Connectors.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda-community-hub/spring-zeebe/issues/256

