### PR TITLE
docs: add alias for Apache 2.0 license (#94)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -362,7 +362,7 @@ limitations under the License.</license.inlineheader>
             <deployMissingFile>false</deployMissingFile>
             <missingFileUrl>https://raw.githubusercontent.com/camunda/connector-sdk/main/licenses/THIRD-PARTY.properties</missingFileUrl>
             <licenseMerges>
-              <licenseMerge>Apache-2.0|Apache License 2.0|Apache License, Version 2.0|The Apache Software License, Version 2.0|Apache 2.0|Apache License, version 2.0|The Apache License, Version 2.0|Apache 2|Apache License|AL 2.0|Apache License v2.0</licenseMerge>
+              <licenseMerge>Apache-2.0|Apache License 2.0|Apache License, Version 2.0|The Apache Software License, Version 2.0|Apache 2.0|Apache License, version 2.0|The Apache License, Version 2.0|Apache 2|Apache License|AL 2.0|ASL 2.0|Apache License v2.0</licenseMerge>
               <licenseMerge>MIT|MIT License|The MIT License|MIT license|The MIT License (MIT)</licenseMerge>
               <licenseMerge>MIT-0</licenseMerge>
               <licenseMerge>BSD-2-Clause|BSD 2-Clause License</licenseMerge>


### PR DESCRIPTION
## Description

ASL 2.0 alias was missing for Apache 2.0 license

## Related issues

https://github.com/camunda/connectors-bundle/pull/94#

closes #

