### PR TITLE
chore(GHA): use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,19 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2.5.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false # we rely on step outputs, no need for environment variables
+        secrets: |
+          secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+          secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
     - name: Checkout
       uses: actions/checkout@v3
 
@@ -20,6 +33,19 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java-version }}
         cache: 'maven'
+
+    # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+    - name: 'Create settings.xml'
+      uses: s4u/maven-settings-action@v2.8.0
+      with:
+        githubServer: false
+        servers: |
+          [{
+             "id": "camunda-nexus",
+             "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+             "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+           }]
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
     - name: Build Maven Artifacts
       run: mvn verify -PcheckFormat

--- a/.github/workflows/DEPLOY.yml
+++ b/.github/workflows/DEPLOY.yml
@@ -33,9 +33,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-          server-id: camunda-nexus
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -96,33 +96,28 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
-      - name: Create ~/.m2/settings.xml 
-        shell: bash
-        run: |
-          cat <<EOF > ~/.m2/settings.xml
-          <?xml version="1.0" encoding="UTF-8"?>
-          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-            <interactiveMode>false</interactiveMode>
-            <servers>
-              <server>
-                <id>camunda-nexus</id>
-                <username>\${env.NEXUS_USR}</username>
-                <password>\${env.NEXUS_PSW}</password>
-              </server>
-              <server>
-                <id>central</id>
-                <username>\${env.MAVEN_USR}</username>
-                <password>\${env.MAVEN_PSW}</password>
-              </server>
-              <server>
-                <id>gpg.passphrase</id>
-                <passphrase>\${env.MAVEN_GPG_PASSPHRASE}</passphrase>
-              </server>
-            </servers>
-          </settings>
-          EOF
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             },
+            {
+               "id": "central",
+               "username": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}",
+               "password": "${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}"
+             },
+            {
+               "id": "gpg.passphrase",
+               "passphrase": "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}",
+             }
+            ]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - name: Configure git user
         run: |
@@ -137,12 +132,6 @@ jobs:
 
       - name: Deploy artifacts to Artifactory and Maven Central
         run: mvn -B compile generate-sources source:jar javadoc:jar deploy -PcheckFormat -Psonatype-oss-release
-        env:
-          NEXUS_USR: ${{ steps.secrets.outputs.ARTIFACTORY_USR }}
-          NEXUS_PSW: ${{ steps.secrets.outputs.ARTIFACTORY_PSW }}
-          MAVEN_USR: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_USR }}
-          MAVEN_PSW: ${{ steps.secrets.outputs.MAVEN_CENTRAL_DEPLOYMENT_PSW }}
-          MAVEN_GPG_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
 
       - name: Commit and tag
         run: |
@@ -184,6 +173,19 @@ jobs:
     needs: [ prepare, release-and-deploy ]
     if: github.ref == 'refs/heads/main' && needs.prepare.output.isPreRelease == 'false'
     steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
       - uses: actions/checkout@v3
 
       - name: Prepare Java and Maven settings
@@ -192,6 +194,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - name: Set next development version
         run: mvn -B build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DgenerateBackupPoms=false -f parent          

--- a/.github/workflows/THIRD_PARTY_NOTICE.yml
+++ b/.github/workflows/THIRD_PARTY_NOTICE.yml
@@ -12,6 +12,19 @@ jobs:
     name: Create third-party notice
     runs-on: ubuntu-latest
     steps:
+      - name: Import Secrets
+        id: secrets # important to refer to it in later steps
+        uses: hashicorp/vault-action@v2.5.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/connectors/ci/common ARTIFACTORY_USR;
+            secret/data/products/connectors/ci/common ARTIFACTORY_PSW;
+
       - uses: actions/checkout@v3
 
       - name: Prepare Java and Maven settings
@@ -20,6 +33,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+      # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: 'Create settings.xml'
+        uses: s4u/maven-settings-action@v2.8.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+               "id": "camunda-nexus",
+               "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+               "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
+             }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       - name: Create notice file
         run: mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party -Dlicense.excludedGroups=io.camunda.connector


### PR DESCRIPTION


## Description

chore(GHA): use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml

## Related issues

 https://github.com/camunda/team-infrastructure/issues/309


