### PR TITLE
chore(GHA): Use Nexus CI as a cache for only Artifactory

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,7 +45,7 @@ jobs:
              "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
              "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
            }]
-        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
     - name: Build Maven Artifacts
       run: mvn verify -PcheckFormat

--- a/.github/workflows/DEPLOY.yml
+++ b/.github/workflows/DEPLOY.yml
@@ -44,7 +44,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -117,7 +117,7 @@ jobs:
                "passphrase": "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}",
              }
             ]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Configure git user
         run: |
@@ -205,7 +205,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Set next development version
         run: mvn -B build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.0-SNAPSHOT -DgenerateBackupPoms=false -f parent          

--- a/.github/workflows/THIRD_PARTY_NOTICE.yml
+++ b/.github/workflows/THIRD_PARTY_NOTICE.yml
@@ -44,7 +44,7 @@ jobs:
                "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
                "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
              }]
-          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "camunda-nexus", "name": "camunda Nexus"}]'
 
       - name: Create notice file
         run: mvn org.codehaus.mojo:license-maven-plugin:aggregate-add-third-party -Dlicense.excludedGroups=io.camunda.connector


### PR DESCRIPTION
Not use the Nexus cache for maven central or non camunda artifacts


## Description

Not use the Nexus cache for maven central or non camunda artifacts

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/309


